### PR TITLE
Add VSCode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,23 @@ runtime directory. For instance, `helix/queries/cognate` (of this repo) to
 `~/.config/helix/runtime/queries/cognate`. Note that Helix should use queries
 under the **`helix/`** directory in this repository.
 
+### VSCode
+
+- [X] Highlights
+
+First install tree-sitter support for VSCode from [here](https://github.com/AlecGhost/tree-sitter-vscode). Then install the `tree-sitter-cognate.vsix` extension from this repository to add support for detecting Cognate files.
+
+Then in the root directory of this repository, run `tree-sitter build-wasm` to create `tree-sitter-cognate.wasm`.
+
+Finally, add these lines to your `settings.json`:
+```json
+"tree-sitter-vscode.languageConfigs": [{
+    "lang": "cognate",
+    "parser": "[PATH_TO_THIS_REPOSITORY]/tree-sitter-cognate.wasm",
+    "highlights": "[PATH_TO_THIS_REPOSITORY]/queries/cognate/highlights.scm",
+}]
+```
+
 ### Vim
 
 Consider using the official vim plugin for vim's regex-based syntax

--- a/vscode/extension/package.json
+++ b/vscode/extension/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "tree-sitter-cognate",
+  "displayName": "Tree Sitter Cognate",
+  "version": "0.1.0",
+  "description": "",
+  "author": "",
+  "license": "MIT",
+  "engines": {
+	"vscode": "^1.63.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "contributes": {
+    "languages": [{
+      "id": "cognate",
+      "aliases": ["Cognate", "cognate"],
+      "extensions": [".cog"]
+    }]
+  }
+}


### PR DESCRIPTION
Unfortunately due to how tree-sitter-vscode is architectured I can't just package everything into an extension -- this is the solution I've come to.

Also, is it worth bundling `tree-sitter-cognate.wasm` to remove a step from the install process?